### PR TITLE
New option and not throw error if context not found

### DIFF
--- a/php_templates.h
+++ b/php_templates.h
@@ -142,7 +142,7 @@ typedef struct _t_template {
 	ulong			config_start, config_end;			/* <template> tag position */
 	zval			*tag_left, *tag_right;				/* tag delimiters */
 	zval			*ctx_ol, *ctx_or, *ctx_cl, *ctx_cr;	/* context delimiters */
-	uchar			ctx_eno;		/* throw error if context block not found */
+	zend_bool		ctx_eno;		/* throw error if context block not found */
 	zval			*tags;			/* sd (single dimensioned) array : tags[path] = (t_tmpl_tag*) */
 	zval			*original;		/* string  : original template content */
 	zval			*path;			/* string : current path */
@@ -197,7 +197,7 @@ ZEND_BEGIN_MODULE_GLOBALS(templates)
 	char	*left, *right;
 	char	*ctx_ol, *ctx_or;
 	char	*ctx_cl, *ctx_cr;
-	uchar	ctx_eno;
+	zend_bool	ctx_eno;
 	zval	*tmpl_param;
 ZEND_END_MODULE_GLOBALS(templates)
 

--- a/php_templates.h
+++ b/php_templates.h
@@ -55,6 +55,7 @@ extern zend_module_entry templates_module_entry;
 #define TMPL_CTX_OR			">"
 #define TMPL_CTX_CL			"</tmpl:"
 #define TMPL_CTX_CR			">"
+#define TMPL_CTX_ENO		1
 
 #define TMPL_CONFIG_TAG_NAME	"template"
 
@@ -141,6 +142,7 @@ typedef struct _t_template {
 	ulong			config_start, config_end;			/* <template> tag position */
 	zval			*tag_left, *tag_right;				/* tag delimiters */
 	zval			*ctx_ol, *ctx_or, *ctx_cl, *ctx_cr;	/* context delimiters */
+	uchar			ctx_eno;		/* throw error if context block not found */
 	zval			*tags;			/* sd (single dimensioned) array : tags[path] = (t_tmpl_tag*) */
 	zval			*original;		/* string  : original template content */
 	zval			*path;			/* string : current path */
@@ -195,6 +197,7 @@ ZEND_BEGIN_MODULE_GLOBALS(templates)
 	char	*left, *right;
 	char	*ctx_ol, *ctx_or;
 	char	*ctx_cl, *ctx_cr;
+	uchar	ctx_eno;
 	zval	*tmpl_param;
 ZEND_END_MODULE_GLOBALS(templates)
 

--- a/templates.c
+++ b/templates.c
@@ -103,6 +103,7 @@ PHP_INI_BEGIN()
     STD_PHP_INI_ENTRY("templates.ctx_or", TMPL_CTX_OR, PHP_INI_ALL, OnUpdateString, ctx_or, zend_templates_globals, templates_globals)
     STD_PHP_INI_ENTRY("templates.ctx_cl", TMPL_CTX_CL, PHP_INI_ALL, OnUpdateString, ctx_cl, zend_templates_globals, templates_globals)
     STD_PHP_INI_ENTRY("templates.ctx_cr", TMPL_CTX_CR, PHP_INI_ALL, OnUpdateString, ctx_cr, zend_templates_globals, templates_globals)
+    STD_PHP_INI_ENTRY("templates.ctx_eno", TMPL_CTX_ENO, PHP_INI_ALL, OnUpdateBool, ctx_eno, zend_templates_globals, templates_globals)
 PHP_INI_END()
 /* }}} */
 
@@ -143,6 +144,7 @@ static void php_templates_init_globals(zend_templates_globals *templates_globals
 	templates_globals->ctx_or = TMPL_CTX_OR;
 	templates_globals->ctx_cl = TMPL_CTX_CL;
 	templates_globals->ctx_cr = TMPL_CTX_CR;
+	templates_globals->ctx_eno = TMPL_CTX_ENO;
 	templates_globals->tmpl_param = NULL;
 }
 /* }}} */
@@ -194,6 +196,7 @@ PHP_RINIT_FUNCTION(templates) {
 	add_assoc_stringl(TMPL_G(tmpl_param), "ctx_or", TMPL_G(ctx_or), strlen(TMPL_G(ctx_or)), 1);
 	add_assoc_stringl(TMPL_G(tmpl_param), "ctx_cl", TMPL_G(ctx_cl), strlen(TMPL_G(ctx_cl)), 1);
 	add_assoc_stringl(TMPL_G(tmpl_param), "ctx_cr", TMPL_G(ctx_cr), strlen(TMPL_G(ctx_cr)), 1);
+	add_assoc_bool(TMPL_G(tmpl_param), "ctx_eno", TMPL_G(ctx_eno));
 
 	return SUCCESS;
 }
@@ -365,6 +368,8 @@ zval			*iteration;
 	MAKE_STD_ZVAL(tmpl->ctx_or);	ZVAL_STRING(tmpl->ctx_or,		  TMPL_CTX_OR, 1);
 	MAKE_STD_ZVAL(tmpl->ctx_cl);	ZVAL_STRING(tmpl->ctx_cl,		  TMPL_CTX_CL, 1);
 	MAKE_STD_ZVAL(tmpl->ctx_cr);	ZVAL_STRING(tmpl->ctx_cr,		  TMPL_CTX_CR, 1);
+
+	tmpl->ctx_eno = TMPL_CTX_ENO;
 
 	MAKE_STD_ZVAL(tmpl->tags);
 	ALLOC_HASHTABLE_REL(Z_ARRVAL_P(tmpl->tags));
@@ -703,7 +708,12 @@ PHP_FUNCTION(tmpl_get) {
 			}
 		}
 	} else {
-		php_error(E_NOTICE, "Tag/context \"%s\" doesn't exist", ZV(real_path));
+		if (tmpl->ctx_eno) {
+			php_error(E_ERROR, "Tag/context \"%s\" doesn't exist", ZV(real_path));
+		} else {
+			php_error(E_NOTICE, "Tag/context \"%s\" doesn't exist", ZV(real_path));
+			RETVAL_STRINGL("", 0, 1);
+		}
 	}
 
 	zval_dtor(real_path); FREE_ZVAL(real_path);

--- a/tmpl_lib.c
+++ b/tmpl_lib.c
@@ -433,7 +433,11 @@ t_tmpl_tag	*tag;
 char		*p;
 
 	if(FAILURE == zend_hash_find(Z_ARRVAL_P(tmpl->tags), ZV(path), ZL(path)+1, (void*)&ztag)) {
-		/* php_error(E_NOTICE, "Can't set value for tag/context \"%s\" which doesn't exist", ZV(path)); */
+		if (tmpl->ctx_eno) {
+			php_error(E_NOTICE, "Can't set value for tag/context \"%s\" which doesn't exist", ZV(path));
+		} else {
+			/* php_error(E_NOTICE, "Can't set value for tag/context \"%s\" which doesn't exist", ZV(path)); */
+		}
 		return FAILURE;
 	}
 	tag = Z_TMPL_TAG(ztag);
@@ -451,8 +455,8 @@ char		*p;
 		}
 	}
 
-	convert_to_string_ex(data); 
-	MAKE_STD_ZVAL(cp_data); 
+	convert_to_string_ex(data);
+	MAKE_STD_ZVAL(cp_data);
 	ZVAL_STRINGL(cp_data, Z_STRVAL_PP(data), Z_STRLEN_PP(data), 1);
 
 	if(SUCCESS == zend_hash_find(Z_ARRVAL_PP(iteration), ZV(tag->name), ZL(tag->name)+1, (void*)&ztag)) {
@@ -556,7 +560,12 @@ zval** php_tmpl_get_iteration(t_template* tmpl, zval* path, int need_new) {
 
 	if(IS_ARRAY != Z_TYPE_PP(cur_data)) { 
 		if(TMPL_TAG == tag->typ) {
-			php_error(E_ERROR, "\"%s\" is inaccessible due to conversion of one of its parent contexts to a tag", ZV(path));
+			if (tmpl->ctx_eno) {
+				php_error(E_ERROR, "\"%s\" is inaccessible due to conversion of one of its parent contexts to a tag", ZV(path));
+			} else {
+				php_error(E_NOTICE, "\"%s\" is inaccessible due to conversion of one of its parent contexts to a tag", ZV(path));
+				return NULL;
+			}
 		} else {
 			php_error(E_ERROR, "The context \"%s\" has been converted to tag", ZV(path));
 		}

--- a/tmpl_lib.c
+++ b/tmpl_lib.c
@@ -489,7 +489,11 @@ zval** php_tmpl_get_iteration(t_template* tmpl, zval* path, int need_new) {
 	t_tmpl_tag		*tag;
 
 	if(FAILURE == zend_hash_find(Z_ARRVAL_P(tmpl->tags), ZV(path), ZL(path)+1, (void*)&ztag)) {
-		php_error(E_ERROR, "Undefined tag/context \"%s\"", ZV(path));
+		if (tmpl->ctx_eno) {
+			php_error(E_ERROR, "Undefined tag/context \"%s\"", ZV(path));
+		} else {
+			php_error(E_NOTICE, "Undefined tag/context \"%s\"", ZV(path));
+		}
 		return NULL;
 	}
 	tag = (t_tmpl_tag*)Z_STRVAL_PP(ztag);
@@ -914,9 +918,16 @@ int				tag_max, tag_cur;
 	break;														\
 }
 
+#define TMPL_SET_PARAM_BOOL(s) {										\
+	zval_dtor(s);												\
+	ZVAL_BOOL((s), Z_BVAL_PP(val));	\
+	param_set = 1;												\
+	break;														\
+}
+
 void php_tmpl_process_param_array(t_template *tmpl, zval *zparam) {
-char*	param[] =		{"left",	"right",	"ctx_ol",	"ctx_or",	"ctx_cl",	"ctx_cr", NULL};
-uint	param_len[] =	{4,			5,			6,			6,			6,			6};
+char*	param[] =		{"left",	"right",	"ctx_ol",	"ctx_or",	"ctx_cl",	"ctx_cr",	"ctx_eno", NULL};
+uint	param_len[] =	{4,			5,			6,			6,			6,			6,			7};
 short	i;
 short	param_set;
 
@@ -944,13 +955,14 @@ uint			nam_len;
 				case 3 : TMPL_SET_PARAM(tmpl->ctx_or);
 				case 4 : TMPL_SET_PARAM(tmpl->ctx_cl);
 				case 5 : TMPL_SET_PARAM(tmpl->ctx_cr);
+				case 6 : TMPL_SET_PARAM_BOOL(tmpl->ctx_eno);
 			}
 
 		}
 
 		if(0 == param_set) {
 			php_error(E_WARNING, "Ignoring unknown template configuration parameter \"%s\"", nam);
-		} else if(!Z_STRLEN_PP(val) && i != 6) {
+		} else if(!Z_STRLEN_PP(val) && i != 7) {
 			php_error(E_ERROR, "Can't continue with empty configuration parameter \"%s\"", nam);
 			return;
 		}

--- a/tmpl_lib.c
+++ b/tmpl_lib.c
@@ -919,8 +919,7 @@ int				tag_max, tag_cur;
 }
 
 #define TMPL_SET_PARAM_BOOL(s) {										\
-	zval_dtor(s);												\
-	ZVAL_BOOL((s), Z_BVAL_PP(val));	\
+	s = Z_BVAL_PP(val);	\
 	param_set = 1;												\
 	break;														\
 }


### PR DESCRIPTION
If some context missing - don't fire fatal errors. Just skip it, but throw notice in log.
